### PR TITLE
Permitted Fields functionality

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ jobs:
             python manage.py migrate
             python manage.py collectstatic
             python manage.py check
-            pytest --doctest-modules --cov-config .coveragerc --cov-report term-missing --durations=0 --cov . -vvv
+            pytest --cov .
             prospector --profile-path . --profile .prospector.yaml .
 
   deploy-staging:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ jobs:
             python manage.py migrate
             python manage.py collectstatic
             python manage.py check
-            pytest --cov .
+            pytest --doctest-modules --cov-config .coveragerc --cov-report term-missing --durations=0 --cov . -vvv
             prospector --profile-path . --profile .prospector.yaml .
 
   deploy-staging:

--- a/_project_/settings.py
+++ b/_project_/settings.py
@@ -285,6 +285,7 @@ REST_FRAMEWORK = {
         'rest_framework.authentication.BasicAuthentication',
     ),
     'DEFAULT_PERMISSION_CLASSES': (
+        'core.api.permissions.DjangoModelViewPermission',
         'rest_framework.permissions.IsAuthenticated',
     ),
     'DEFAULT_THROTTLE_CLASSES': (),

--- a/conftest.py
+++ b/conftest.py
@@ -1,7 +1,6 @@
 from contextlib import contextmanager
 import os
 
-from rest_framework.test import APIClient
 from selenium import webdriver
 import pytest
 
@@ -21,6 +20,7 @@ TransactionTestCase.serialized_rollback = True
 
 @pytest.fixture()
 def anon_api_client():
+    from rest_framework.test import APIClient
     return APIClient()
 
 
@@ -36,6 +36,7 @@ def api_user():
 
 @pytest.fixture
 def api_client(api_user):
+    from rest_framework.test import APIClient
     client = APIClient()
     client.force_login(api_user)
     return client

--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,7 @@
 from contextlib import contextmanager
 import os
 
+from rest_framework.test import APIClient
 from selenium import webdriver
 import pytest
 
@@ -16,6 +17,28 @@ from _project_ import celery_app as django_celery_app
 # Transaction rollback emulation
 # http://docs.djangoproject.com/en/2.0/topics/testing/overview/#rollback-emulation
 TransactionTestCase.serialized_rollback = True
+
+
+@pytest.fixture()
+def anon_api_client():
+    return APIClient()
+
+
+@pytest.fixture
+def api_user():
+    from django.contrib.auth import get_user_model
+    user_model = get_user_model()
+    user = user_model(username='test', email='test@test.ru', is_active=True)
+    user.set_password('test_password')
+    user.save()
+    return user
+
+
+@pytest.fixture
+def api_client(api_user):
+    client = APIClient()
+    client.force_login(api_user)
+    return client
 
 
 def pytest_configure():

--- a/contacts/admin.py
+++ b/contacts/admin.py
@@ -20,11 +20,6 @@ class ContactAdmin(SecuredVersionedModelAdmin):
         )}),
     )
 
-    permitted_fields = {
-        'contacts.change_contact': [
-            'name', 'phones', 'emails', 'order_index']
-    }
-
     def display_emails(self, obj):  # noqa: pylint=no-self-use
         return format_html_join(
             mark_safe('<br>'), '<a href="mailto:{0}">{0}</a>',

--- a/contacts/api/serializers.py
+++ b/contacts/api/serializers.py
@@ -1,3 +1,5 @@
+from rest_framework.fields import IntegerField
+
 from core.api.fields import PrimaryKeyModelSerializerField
 from core.api.serializers import StandardizedModelSerializer
 from ..models import Contact, Comment
@@ -18,8 +20,14 @@ class ContactSerializer(StandardizedModelSerializer):
 class CommentSerializer(StandardizedModelSerializer):
     contact = PrimaryKeyModelSerializerField(
         ContactSerializer,
-        allowed_objects=lambda serializer: serializer.Meta.model.objects.all()
-    )
+        allowed_objects=lambda serializer: serializer.Meta.model.objects.all())
+
+    user = IntegerField(source='user_id', required=False)
+
+    def create(self, validated_data):
+        if 'user' not in validated_data:
+            validated_data['user'] = self.context['request'].user
+        return super().create(validated_data)
 
     class Meta:
         model = Comment

--- a/contacts/api/viewsets.py
+++ b/contacts/api/viewsets.py
@@ -45,6 +45,3 @@ class CommentViewSet(StandardizedModelViewSet):
 
     def get_queryset(self):
         return Comment.objects.all().select_related('contact')
-
-    def perform_create(self, serializer):
-        serializer.save(user=self.request.user)

--- a/contacts/migrations/0005_auto_20180216_1255.py
+++ b/contacts/migrations/0005_auto_20180216_1255.py
@@ -30,7 +30,7 @@ class Migration(migrations.Migration):
                 'verbose_name': 'коментарий',
                 'verbose_name_plural': 'коментарии',
                 'ordering': ['-created'],
-                'permissions': (('can_edit_comment', 'Может редактировать коментарий'), ('can_get_api_comment_history', 'Может читать /api/v<X>/comment-list/history/')),
+                'permissions': (('change_user_comment', 'Может менять автора коментария'), ('can_get_api_comment_history', 'Может читать /api/v<X>/comment-list/history/')),
             },
         ),
         migrations.CreateModel(

--- a/contacts/migrations/0007_auto_20180605_1058.py
+++ b/contacts/migrations/0007_auto_20180605_1058.py
@@ -17,7 +17,7 @@ class Migration(migrations.Migration):
     operations = [
         migrations.AlterModelOptions(
             name='comment',
-            options={'ordering': ['-created'], 'permissions': (('can_edit_comment', 'Может редактировать коментарий'),), 'verbose_name': 'коментарий', 'verbose_name_plural': 'коментарии'},
+            options={'ordering': ['-created'], 'permissions': (('change_user_comment', 'Может менять автора коментария'),), 'verbose_name': 'коментарий', 'verbose_name_plural': 'коментарии'},
         ),
         migrations.AlterModelOptions(
             name='contact',

--- a/contacts/models.py
+++ b/contacts/models.py
@@ -5,6 +5,11 @@ from pik.core.models import BaseHistorical, BasePHistorical, Owned
 
 
 class Contact(BaseHistorical):
+    permitted_fields = {
+        '{app_label}.change_{model_name}': [
+            'name', 'phones', 'emails', 'order_index']
+    }
+
     name = models.CharField(_('Наименование'), max_length=255)
     phones = ArrayField(
         models.CharField(max_length=30), blank=True, default=list,
@@ -32,6 +37,11 @@ class Contact(BaseHistorical):
 
 
 class Comment(BasePHistorical, Owned):
+    permitted_fields = {
+        '{app_label}.change_{model_name}': ['message', 'contact'],
+        '{app_label}.change_user_{model_name}': ['user_id']
+    }
+
     contact = models.ForeignKey(
         Contact, related_name='comments',
         on_delete=models.CASCADE)
@@ -45,5 +55,6 @@ class Comment(BasePHistorical, Owned):
         verbose_name_plural = _('коментарии')
         ordering = ['-created']
         permissions = (
-            ("can_edit_comment", _("Может редактировать коментарий")),
+            ("change_user_comment",
+             _("Может менять автора комментария")),
         )

--- a/contacts/models.py
+++ b/contacts/models.py
@@ -56,5 +56,5 @@ class Comment(BasePHistorical, Owned):
         ordering = ['-created']
         permissions = (
             ("change_user_comment",
-             _("Может менять автора комментария")),
+             _("Может менять автора коментария")),
         )

--- a/contacts/tests/test_api_auto_generated_history_cases.py
+++ b/contacts/tests/test_api_auto_generated_history_cases.py
@@ -1,10 +1,8 @@
-from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
 import pytest
 from rest_framework import status
-from rest_framework.test import APIClient
 
-from core.tasks.fixtures import create_user
+from core.tests.utils import add_permissions
 from ..models import Contact, Comment
 from ..tests.factories import ContactFactory, CommentFactory
 
@@ -20,20 +18,6 @@ def api_model(request):
     return request.param
 
 
-@pytest.fixture()
-def client():
-    return APIClient()
-
-
-@pytest.fixture
-def api_client():
-    user = create_user()
-    client = APIClient()
-    client.force_login(user)
-    client.user = user
-    return client
-
-
 def _url(model, options):
     _type = ContentType.objects.get_for_model(model).model
     return f'/api/v{options["version"]}/{_type}-list/history/'
@@ -43,16 +27,6 @@ def _create_few_models(factory):
     factory.create_batch(BATCH_MODELS)
     last_obj = factory.create()
     return last_obj
-
-
-def _create_history_permission(user, model):
-    model = model.history.model
-    opts = model._meta  # noqa: pylint=protected-access
-    content_type = ContentType.objects.get_for_model(model)
-    permission = Permission.objects.get(
-        content_type=content_type,
-        codename=f'view_{opts.model_name}')
-    user.user_permissions.add(permission)
 
 
 def _assert_history_object(hist_obj, type_, event_, uid_):
@@ -79,25 +53,25 @@ def test_api_history_access_denied(api_client, api_model):
         'message': 'У вас нет прав для выполнения этой операции.'}
 
 
-def test_api_history(api_client, api_model):
+def test_api_history(api_user, api_client, api_model):
     model, factory, options = api_model
     _create_few_models(factory)
     url = _url(model, options)
 
-    _create_history_permission(api_client.user, model)
+    add_permissions(api_user, model.history.model, 'view')
     res = api_client.get(url)
 
     assert res.status_code == status.HTTP_200_OK
     assert len(res.data['results']) == BATCH_MODELS + 1
 
 
-def test_api_history_filter_by_uid(api_client, api_model):
+def test_api_history_filter_by_uid(api_user, api_client, api_model):
     model, factory, options = api_model
     last_obj = _create_few_models(factory)
     url = _url(model, options)
     _type = ContentType.objects.get_for_model(model).model
 
-    _create_history_permission(api_client.user, model)
+    add_permissions(api_user, model.history.model, 'view')
     res = api_client.get(f'{url}?_uid={last_obj.uid}')
 
     assert res.status_code == status.HTTP_200_OK
@@ -110,12 +84,12 @@ def test_api_history_filter_by_uid(api_client, api_model):
     assert first_result['history_type'] == "+"
 
 
-def test_api_history_filter_by_date(api_client, api_model):
+def test_api_history_filter_by_date(api_user, api_client, api_model):
     model, factory, options = api_model
     last_obj = _create_few_models(factory)
     url = _url(model, options)
 
-    _create_history_permission(api_client.user, model)
+    add_permissions(api_user, model.history.model, 'view')
     last_obj.save()
     history = last_obj.history.last()
     history.history_date = '2000-01-01 00:00:00'
@@ -138,12 +112,13 @@ def test_api_history_filter_by_date(api_client, api_model):
     assert len(res.data['results']) == 6
 
 
-def test_api_history_create_and_change(api_client, api_model):  # noqa: invalid-name (pylint bug)
+def test_api_history_create_and_change(api_user, api_client, api_model):  # noqa: invalid-name (pylint bug)
     model, factory, options = api_model
     last_obj = _create_few_models(factory)
     url = _url(model, options)
 
-    _create_history_permission(api_client.user, model)
+    add_permissions(api_user, model.history.model, 'view')
+
     last_obj.save()
     res = api_client.get(f'{url}?_uid={last_obj.uid}')
 

--- a/contacts/tests/test_api_v1_create.py
+++ b/contacts/tests/test_api_v1_create.py
@@ -1,44 +1,31 @@
+from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
 from django.utils.crypto import get_random_string
-import pytest
 from rest_framework import status
-from rest_framework.test import APIClient
 
-from core.tasks.fixtures import create_user
+from contacts.models import Contact, Comment
+from core.tests.utils import add_permissions
 from ..tests.factories import ContactFactory
 
 
 REQUIRED_FIELD_ERROR = {'message': 'Это поле обязательно.', 'code': 'required'}
 
 
-@pytest.fixture()
-def client():
-    return APIClient()
-
-
-@pytest.fixture
-def api_client():
-    user = create_user()
-    client = APIClient()
-    client.force_login(user)
-    client.user = user
-    return client
-
-
-def test_api_unauthorized(client):
-    res = client.get('/api/v1/')
+def test_api_unauthorized(anon_api_client):
+    res = anon_api_client.get('/api/v1/')
     assert res.status_code in (status.HTTP_401_UNAUTHORIZED,
                                status.HTTP_403_FORBIDDEN)
 
 
-def test_api_create_contact_unauthorized(client):  # noqa: pylint=invalid-name
+def test_api_create_contact_unauthorized(anon_api_client):  # noqa: pylint=invalid-name
     data = {'name': get_random_string()}
-    res = client.post('/api/v1/contact-list/', data=data)
+    res = anon_api_client.post('/api/v1/contact-list/', data=data)
     assert res.status_code in (status.HTTP_401_UNAUTHORIZED,
                                status.HTTP_403_FORBIDDEN)
 
 
-def test_api_create_contact_without_name(api_client):  # noqa: pylint=invalid-name
+def test_api_create_contact_without_name(api_user, api_client):  # noqa: pylint=invalid-name
+    add_permissions(api_user, Contact, 'add')
     data = {'noname': get_random_string()}
     res = api_client.post('/api/v1/contact-list/', data=data)
     assert res.status_code == status.HTTP_400_BAD_REQUEST
@@ -49,33 +36,37 @@ def test_api_create_contact_without_name(api_client):  # noqa: pylint=invalid-na
         'message': 'Invalid input.'}
 
 
-def test_api_create_contact_with_extra_field(api_client):  # noqa: pylint=invalid-name
+def test_api_create_contact_with_extra_field(api_user, api_client):  # noqa: pylint=invalid-name
+    add_permissions(api_user, Contact, 'add', 'change')
     data = {'name': get_random_string(), 'fooo': 'no'}
     res = api_client.post('/api/v1/contact-list/', data=data)
     assert res.status_code == status.HTTP_201_CREATED
 
 
-def test_api_create_contact(api_client):
+def test_api_create_contact(api_user, api_client):
+    add_permissions(api_user, Contact, 'add', 'change')
     data = {'name': get_random_string()}
     res = api_client.post('/api/v1/contact-list/', data=data)
     assert res.status_code == status.HTTP_201_CREATED
 
 
-def test_api_create_bulk_contact(api_client):
+def test_api_create_bulk_contact(api_user, api_client):
+    add_permissions(api_user, Contact, 'add', 'change')
     data = [{'name': get_random_string()}, {'name': get_random_string()}]
     res = api_client.post('/api/v1/contact-list/', data=data)
     assert res.status_code == status.HTTP_201_CREATED
     assert len(res.data) == 2
 
 
-def test_api_create_comment_unauthorized(client):  # noqa: pylint=invalid-name
+def test_api_create_comment_unauthorized(anon_api_client):  # noqa: pylint=invalid-name
     data = {'message': get_random_string()}
-    res = client.post('/api/v1/comment-list/', data=data)
+    res = anon_api_client.post('/api/v1/comment-list/', data=data)
     assert res.status_code in (status.HTTP_401_UNAUTHORIZED,
                                status.HTTP_403_FORBIDDEN)
 
 
-def test_api_create_comment_without_contact(api_client):  # noqa: pylint=invalid-name
+def test_api_create_comment_without_contact(api_user, api_client):  # noqa: pylint=invalid-name
+    add_permissions(api_user, Comment, 'add')
     data = {'message': get_random_string()}
     res = api_client.post('/api/v1/comment-list/', data=data)
     assert res.status_code == status.HTTP_400_BAD_REQUEST
@@ -87,29 +78,58 @@ def test_api_create_comment_without_contact(api_client):  # noqa: pylint=invalid
     }
 
 
-def test_api_create_comment(api_client):
+def test_api_create_comment(api_user, api_client):
     contact = ContactFactory.create()
+    add_permissions(api_user, Comment, 'add', 'change')
     payload = {
         '_uid': contact.uid,
         '_type': ContentType.objects.get_for_model(type(contact)).model,
         'name': get_random_string(),
     }
-
     data = {'message': get_random_string(), 'contact': payload}
     res = api_client.post('/api/v1/comment-list/', data=data)
     assert res.status_code == status.HTTP_201_CREATED
-    assert res.data['user'] == api_client.user.pk
+    assert res.data['user'] == api_user.pk
 
 
-def test_api_create_comment_simple(api_client):
-    contact = ContactFactory.create()
+def test_api_create_comment_simple(api_user, api_client):
+    contact = ContactFactory.create(name=api_user.username)
+    add_permissions(api_user, Comment, 'add', 'change')
     data = {'message': get_random_string(), 'contact': contact.uid}
     res = api_client.post('/api/v1/comment-list/', data=data)
     assert res.status_code == status.HTTP_201_CREATED
-    assert res.data['user'] == api_client.user.pk
+    assert res.data['user'] == api_user.pk
 
 
-def test_api_create_2_comments_for_one_contact(api_client):  # noqa: pylint=invalid-name
+def test_api_create_comment_otheruser(api_user, api_client):
+    other_user = get_user_model().objects.create(username='other')
+    contact = ContactFactory.create(name=api_user.username)
+    add_permissions(api_user, Comment, 'add', 'change', 'change_user')
+    data = {'message': get_random_string(), 'contact': contact.uid,
+            'user': other_user.pk}
+    res = api_client.post('/api/v1/comment-list/', data=data)
+    assert res.status_code == status.HTTP_201_CREATED
+    assert res.data['user'] == other_user.pk
+
+
+def test_api_create_comment_otheruser_permitted(api_user, api_client):
+    other_user = get_user_model().objects.create(username='other')
+    contact = ContactFactory.create(name=api_user.username)
+    add_permissions(api_user, Comment, 'add', 'change')
+    data = {'message': get_random_string(), 'contact': contact.uid,
+            'user': other_user.pk}
+    res = api_client.post('/api/v1/comment-list/', data=data)
+    assert res.status_code == status.HTTP_400_BAD_REQUEST
+    assert res.json() == {
+        'code': 'invalid',
+        'detail': {'user_id': [{
+            'code': 'invalid',
+            'message': 'У вас нет прав для редактирования этого поля.'}]},
+        'message': 'Invalid input.'}
+
+
+def test_api_create_2_comments_for_one_contact(api_user, api_client):  # noqa: pylint=invalid-name
+    add_permissions(api_user, Comment, 'add', 'change')
     contact = ContactFactory.create()
     payload = {
         '_uid': contact.uid,

--- a/core/admin.py
+++ b/core/admin.py
@@ -1,6 +1,7 @@
 from django.contrib.gis import admin
-from django.forms import modelform_factory, ALL_FIELDS
 from simple_history.admin import SimpleHistoryAdmin
+
+from core.permitted_fields.admin import PermittedFieldsAdminMixIn
 
 
 class ReasonedMixIn:
@@ -25,45 +26,6 @@ class ReasonedMixIn:
         super().delete_model(request, obj)
 
 
-class PermittedFieldsMixIn:
-    permitted_fields = dict()
-
-    def _has_view_permission_only(self, request, obj):
-        if obj is None:
-            return not self.has_add_permission(request)
-
-        return (self.has_view_permission(request, obj)
-                and not self.has_change_permission(request, obj))
-
-    def get_model_fields(self, obj):
-        form_class = modelform_factory(self.model, self.form, ALL_FIELDS)
-        form = form_class(instance=obj)
-        return form.fields.keys()
-
-    def get_readonly_fields(self, request, obj=None):
-        if self._has_view_permission_only(request, obj):
-            return super().get_readonly_fields(request, obj)
-
-        fields = {
-            field
-            for field in self.get_model_fields(obj)
-            if not self.has_field_permission(request, field)
-        }
-        return list(set(super().get_readonly_fields(request, obj)) | fields)
-
-    def has_field_permission(self, request, field):
-        if not self.permitted_fields:
-            return False
-        for permission, _fields in self.permitted_fields.items():
-            meta = self.model._meta  # noqa: protected-access
-            permission = permission.format(app_label=meta.app_label.lower(),
-                                           model_name=meta.object_name.lower())
-            has_perm = (field in _fields and request.user.has_perm(permission))
-            if has_perm:
-                return True
-        return False
-
-
 class NonDeletableModelAdminMixIn:
     def has_delete_permission(self, request, obj=None):  # noqa: pylint=no-self-use
         return False
@@ -84,7 +46,8 @@ class StrictMixIn(NonAddableModelAdminMixIn, NonDeletableModelAdminMixIn):
     pass
 
 
-class SecuredModelAdmin(PermittedFieldsMixIn, ReasonedMixIn, admin.ModelAdmin):
+class SecuredModelAdmin(PermittedFieldsAdminMixIn, ReasonedMixIn,
+                        admin.ModelAdmin):
     pass
 
 
@@ -92,7 +55,7 @@ class StrictSecuredModelAdmin(StrictMixIn, SecuredModelAdmin):
     pass
 
 
-class SecuredAdminInline(PermittedFieldsMixIn, ReasonedMixIn,
+class SecuredAdminInline(PermittedFieldsAdminMixIn, ReasonedMixIn,
                          admin.TabularInline):
     extra = 0
 

--- a/core/api/permissions.py
+++ b/core/api/permissions.py
@@ -1,0 +1,7 @@
+from rest_framework import permissions
+
+
+class DjangoModelViewPermission(permissions.DjangoModelPermissions):
+
+    perms_map = {**permissions.DjangoModelPermissions.perms_map,
+                 **{'GET': ['%(app_label)s.view_%(model_name)s']}}

--- a/core/api/serializers.py
+++ b/core/api/serializers.py
@@ -5,8 +5,10 @@ from django.contrib.contenttypes.models import ContentType
 from django.db.models import Model
 from rest_framework import serializers
 
+from core.permitted_fields.api import PermittedFieldsSerializerMixIn
 
-class StandardizedModelSerializer(serializers.ModelSerializer):
+
+class StandardizedProtocolSerializer(serializers.ModelSerializer):
     _uid = serializers.SerializerMethodField()
     _type = serializers.SerializerMethodField()
     _version = serializers.SerializerMethodField()
@@ -27,3 +29,9 @@ class StandardizedModelSerializer(serializers.ModelSerializer):
         if not hasattr(obj, 'version'):
             return None
         return obj.version
+
+
+class StandardizedModelSerializer(StandardizedProtocolSerializer,
+                                  PermittedFieldsSerializerMixIn,
+                                  serializers.ModelSerializer):
+    pass

--- a/core/permitted_fields/README.md
+++ b/core/permitted_fields/README.md
@@ -1,0 +1,65 @@
+Permitted Fields library provides per field permissions limitation.
+
+permitted_fields - is Model, ModelAdmin or Serializer defined property. It 
+defines permissions which are required for field edition.
+
+Example:
+
+```python
+class Comment(Model):
+	permitted_fields = {
+		"comments.change_comment": ['user', 'text'],
+		"comments.change_user_comment": ['user']
+	}
+	
+	user = ForeignKey(User)
+	text = TextField()
+```
+
+This construction defines `text` field `change_contact` permission requirement,
+and `change_comment`+`change_user_comment` permissions for `user` field.
+
+It is possible to use templates in permission names:
+
+```python
+class Comment(Model):
+	permitted_fields = {
+		"{app_label}.change_{model_name}": ['user', 'text'],
+		"{app_label}.change_user_{model_name}": ['user']
+	}
+
+	user = ForeignKey(User)
+	text = TextField()
+
+```
+
+These restrictions may be defined for `Model` as for 
+`SecuredVersionedModelAdmin` and `StandardizedModelSerializer` if default model
+behaviour overriding needed.
+
+```python
+@admin.register(Comment)
+class CommentAdmin(SecuredVersionedModelAdmin):
+	permitted_fields = {
+		"{app_label}.change_{model_name}": ['user', 'text'],
+		"{app_label}.change_user_{model_name}": ['user']
+	}
+
+```
+
+```python
+class CommentSerializer(StandardizedModelSerializer):
+    permitted_fields = {
+        "{app_label}.change_{model_name}": ['user', 'text'],
+        "{app_label}.change_user_{model_name}": ['user']
+    }
+    class Meta:
+        model = Comment
+        read_only_fields = (
+            '_uid', '_type', '_version', 'user',
+        )
+        fields = (
+            '_uid', '_type', '_version', 'user', 'text',
+        )
+
+```

--- a/core/permitted_fields/admin.py
+++ b/core/permitted_fields/admin.py
@@ -1,0 +1,29 @@
+from django.forms import ALL_FIELDS, modelform_factory
+
+from .permitted import PermittedFieldsPermissionMixIn
+
+
+class PermittedFieldsAdminMixIn(PermittedFieldsPermissionMixIn):
+    def _has_view_permission_only(self, request, obj):
+        if obj is None:
+            return not self.has_add_permission(request)
+
+        return (self.has_view_permission(request, obj)
+                and not self.has_change_permission(request, obj))
+
+    def get_model_fields(self, obj):
+        form_class = modelform_factory(self.model, self.form, ALL_FIELDS)
+        form = form_class(instance=obj)
+        return form.fields.keys()
+
+    def get_readonly_fields(self, request, obj=None):
+        if self._has_view_permission_only(request, obj):
+            return super().get_readonly_fields(request, obj)
+
+        fields = {
+            field
+            for field in self.get_model_fields(obj)
+            if not self.has_field_permission(request.user, self.model, field)
+        }
+        original = set(super().get_readonly_fields(request, obj))
+        return list(original | fields)

--- a/core/permitted_fields/api.py
+++ b/core/permitted_fields/api.py
@@ -1,0 +1,28 @@
+from django.utils.translation import ugettext_lazy as _
+
+from rest_framework.exceptions import ValidationError
+
+from .permitted import PermittedFieldsPermissionMixIn
+
+
+class PermittedFieldsSerializerMixIn(PermittedFieldsPermissionMixIn):
+    default_error_messages = {
+        'field_permission_denied': _('У вас нет прав для '
+                                     'редактирования этого поля.')
+    }
+
+    def to_internal_value(self, request_data):
+        errors = {}
+        ret = super().to_internal_value(request_data)
+        user = self.context['request'].user
+        model = self.Meta.model
+
+        for field in ret.keys():
+            if self.has_field_permission(user, model, field):
+                continue
+            errors[field] = [self.error_messages['field_permission_denied']]
+
+        if errors:
+            raise ValidationError(errors)
+
+        return ret

--- a/core/permitted_fields/permitted.py
+++ b/core/permitted_fields/permitted.py
@@ -1,0 +1,14 @@
+class PermittedFieldsPermissionMixIn:
+    def has_field_permission(self, user, model, field):
+        permitted_fields = getattr(self, 'permitted_fields',
+                                   getattr(model, 'permitted_fields', None))
+        if not permitted_fields:
+            return False
+        for permission, _fields in permitted_fields.items():
+            meta = model._meta  # noqa: protected-access
+            permission = permission.format(app_label=meta.app_label.lower(),
+                                           model_name=meta.object_name.lower())
+            has_perm = (field in _fields and user.has_perm(permission))
+            if has_perm:
+                return True
+        return False

--- a/core/permitted_fields/tests/test_admin/test_has_view_permission_only.py
+++ b/core/permitted_fields/tests/test_admin/test_has_view_permission_only.py
@@ -1,23 +1,8 @@
 from unittest.mock import Mock
 
-import pytest
-
 from core.permitted_fields.admin import PermittedFieldsAdminMixIn
 
-try:
-    import admin_view_permission  # noqa unused-import
-except ImportError:
-    VIEW_PERMISSION = False
-else:
-    VIEW_PERMISSION = True
 
-
-skip_admin_view_permission_missing = pytest.mark.skipif(  # noqa
-    not VIEW_PERMISSION,
-    reason='Django Admin View permission is missing')
-
-
-@skip_admin_view_permission_missing
 def test_obj_view_only():
     admin = PermittedFieldsAdminMixIn()
     admin.has_view_permission = Mock(return_value=True)
@@ -26,7 +11,6 @@ def test_obj_view_only():
     assert admin._has_view_permission_only(request=Mock(), obj=Mock())  # noqa  protected-access
 
 
-@skip_admin_view_permission_missing
 def test_obj_view_and_change():
     admin = PermittedFieldsAdminMixIn()
     admin.has_view_permission = Mock(return_value=True)
@@ -35,7 +19,6 @@ def test_obj_view_and_change():
     assert not admin._has_view_permission_only(request=Mock(), obj=Mock())  # noqa  protected-access
 
 
-@skip_admin_view_permission_missing
 def test_missing_obj_add_permission():
     admin = PermittedFieldsAdminMixIn()
     admin.has_add_permission = Mock(return_value=True)
@@ -43,7 +26,6 @@ def test_missing_obj_add_permission():
     assert not admin._has_view_permission_only(request=Mock(), obj=None)  # noqa  protected-access
 
 
-@skip_admin_view_permission_missing
 def test_missing_obj_add_permission_missing(): # noqa: invalid-name
     admin = PermittedFieldsAdminMixIn()
     admin.has_add_permission = Mock(return_value=False)

--- a/core/permitted_fields/tests/test_admin/test_has_view_permission_only.py
+++ b/core/permitted_fields/tests/test_admin/test_has_view_permission_only.py
@@ -1,0 +1,51 @@
+from unittest.mock import Mock
+
+import pytest
+
+from core.permitted_fields.admin import PermittedFieldsAdminMixIn
+
+try:
+    import admin_view_permission  # noqa unused-import
+except ImportError:
+    VIEW_PERMISSION = False
+else:
+    VIEW_PERMISSION = True
+
+
+skip_admin_view_permission_missing = pytest.mark.skipif(  # noqa
+    not VIEW_PERMISSION,
+    reason='Django Admin View permission is missing')
+
+
+@skip_admin_view_permission_missing
+def test_obj_view_only():
+    admin = PermittedFieldsAdminMixIn()
+    admin.has_view_permission = Mock(return_value=True)
+    admin.has_change_permission = Mock(return_value=False)  # noqa  protected-access
+
+    assert admin._has_view_permission_only(request=Mock(), obj=Mock())  # noqa  protected-access
+
+
+@skip_admin_view_permission_missing
+def test_obj_view_and_change():
+    admin = PermittedFieldsAdminMixIn()
+    admin.has_view_permission = Mock(return_value=True)
+    admin.has_change_permission = Mock(return_value=True)  # noqa  protected-access
+
+    assert not admin._has_view_permission_only(request=Mock(), obj=Mock())  # noqa  protected-access
+
+
+@skip_admin_view_permission_missing
+def test_missing_obj_add_permission():
+    admin = PermittedFieldsAdminMixIn()
+    admin.has_add_permission = Mock(return_value=True)
+
+    assert not admin._has_view_permission_only(request=Mock(), obj=None)  # noqa  protected-access
+
+
+@skip_admin_view_permission_missing
+def test_missing_obj_add_permission_missing(): # noqa: invalid-name
+    admin = PermittedFieldsAdminMixIn()
+    admin.has_add_permission = Mock(return_value=False)
+
+    assert admin._has_view_permission_only(request=Mock(), obj=None)  # noqa  protected-access

--- a/core/permitted_fields/tests/test_permitted.py
+++ b/core/permitted_fields/tests/test_permitted.py
@@ -1,0 +1,54 @@
+from unittest import mock
+
+import pytest
+
+from ..permitted import PermittedFieldsPermissionMixIn
+
+
+@pytest.fixture
+def model():
+    return mock.Mock(
+        permitted_fields={'{app_label}_can_change_{model_name}': ['a']},
+        _meta=mock.Mock(
+            app_label='MockApp',
+            object_name='MockModel'
+        )
+    )
+
+
+def test_perm_format(model):
+    user = mock.Mock()
+    PermittedFieldsPermissionMixIn().has_field_permission(
+        user=user, model=model, field='a')
+    calls = [mock.call('mockapp_can_change_mockmodel')]
+    assert user.has_perm.mock_calls == calls
+
+
+def test_got_field_and_perm(model):
+    user_with_perm = mock.Mock(has_perm=mock.Mock(return_value=True))
+
+    a_is_editable = PermittedFieldsPermissionMixIn().has_field_permission(
+        user=user_with_perm, model=model, field='a')
+    assert a_is_editable
+
+
+def test_missing_field(model):
+    user_with_perm = mock.Mock(has_perm=mock.Mock(return_value=True))
+
+    b_is_editable = PermittedFieldsPermissionMixIn().has_field_permission(
+        user=user_with_perm, model=model, field='b')
+    assert not b_is_editable
+
+
+def test_missing_perm(model):
+    user_without_perm = mock.Mock(has_perm=mock.Mock(return_value=False))
+    a_is_editable = PermittedFieldsPermissionMixIn().has_field_permission(
+        user=user_without_perm, model=model, field='a')
+    assert not a_is_editable
+
+
+def test_missing_perm_and_field(model):
+    user_without_perm = mock.Mock(has_perm=mock.Mock(return_value=False))
+    a_is_editable = PermittedFieldsPermissionMixIn().has_field_permission(
+        user=user_without_perm, model=model, field='b')
+    assert not a_is_editable

--- a/core/permitted_fields/tests/test_serializer.py
+++ b/core/permitted_fields/tests/test_serializer.py
@@ -1,0 +1,37 @@
+from unittest.mock import Mock, patch
+
+import pytest
+from rest_framework.exceptions import ValidationError
+from rest_framework.serializers import ModelSerializer
+
+from core.permitted_fields.api import PermittedFieldsSerializerMixIn
+
+
+@patch('rest_framework.serializers.ModelSerializer.to_internal_value',
+       Mock(return_value={'a': 1, 'b': 2}))
+def test_error():
+    class TestSerializer(PermittedFieldsSerializerMixIn, ModelSerializer):
+        class Meta:
+            model = Mock()
+
+        def has_field_permission(self, user, model, field):
+            return field == 'a'
+
+    serializer = TestSerializer(context={'request': Mock()})
+    message = {'b': ['У вас нет прав для редактирования этого поля.']}
+    with pytest.raises(ValidationError, message=message):
+        serializer.to_internal_value({'a': 1, 'b': 2})
+
+
+@patch('rest_framework.serializers.ModelSerializer.to_internal_value',
+       Mock(return_value={'a': 1, 'b': 2}))
+def test_success():
+    class TestSerializer(PermittedFieldsSerializerMixIn, ModelSerializer):
+        class Meta:
+            model = Mock()
+
+        def has_field_permission(self, user, model, field):
+            return True
+
+    serializer = TestSerializer(context={'request': Mock()})
+    assert serializer.to_internal_value({'a': 1, 'b': 2}) == {'a': 1, 'b': 2}

--- a/core/tests/test_api_auth.py
+++ b/core/tests/test_api_auth.py
@@ -1,20 +1,14 @@
-import pytest
 from django.utils.crypto import get_random_string
 from rest_framework import status
-from rest_framework.test import APIClient
 
 from core.tasks.fixtures import create_user
+
 
 REQUIRED_FIELD_ERROR = {'message': 'Это поле обязательно.', 'code': 'required'}
 
 
-@pytest.fixture()
-def client():
-    return APIClient()
-
-
-def test_api_token_auth_without_data(client):  # noqa: pylint=invalid-name
-    res = client.post('/api-token-auth/', data={})
+def test_api_token_auth_without_data(anon_api_client):  # noqa: pylint=invalid-name
+    res = anon_api_client.post('/api-token-auth/', data={})
 
     assert res.status_code == status.HTTP_400_BAD_REQUEST
     assert res.data == {
@@ -26,14 +20,14 @@ def test_api_token_auth_without_data(client):  # noqa: pylint=invalid-name
         'message': 'Invalid input.'}
 
 
-def test_api_token_auth(client):
+def test_api_token_auth(anon_api_client):
     user = create_user()
     username = getattr(user, user.USERNAME_FIELD)
     password = get_random_string()
     user.set_password(password)
     user.save()
 
-    res = client.post('/api-token-auth/', data={
+    res = anon_api_client.post('/api-token-auth/', data={
         'username': username, 'password': password})
 
     assert res.status_code == status.HTTP_200_OK

--- a/core/tests/test_api_v1.py
+++ b/core/tests/test_api_v1.py
@@ -1,18 +1,6 @@
-import pytest
-import django.test
-from pik.core.tests import create_user
 from rest_framework import status
 
 
-@pytest.fixture
-def logged_user_client(client: django.test.Client):
-    user = create_user()
-    user.save()
-    client.force_login(user)
-    client.user = user
-    return client
-
-
-def test_smoke_schema(logged_user_client):
-    res = logged_user_client.get('/api/v1/schema/')
+def test_smoke_schema(api_client):
+    res = api_client.get('/api/v1/schema/')
     assert res.status_code == status.HTTP_200_OK

--- a/core/tests/utils.py
+++ b/core/tests/utils.py
@@ -1,0 +1,11 @@
+from django.contrib.contenttypes.models import ContentType
+from django.contrib.auth.models import Permission
+
+
+def add_permissions(user, model, *actions):
+    ctype = ContentType.objects.get_for_model(model)
+    user.user_permissions.add(*(
+        Permission.objects.get(codename=f'{action}_{model.__name__.lower()}',
+                               content_type=ctype)
+        for action in actions
+    ))

--- a/cors/admin.py
+++ b/cors/admin.py
@@ -9,4 +9,3 @@ from cors.models import Cors
 class CorsAdmin(SecuredVersionedModelAdmin):
     list_display = ['cors']
     search_fields = ['cors']
-    permitted_fields = {'{app_label}.change_{model_name}': ['cors']}

--- a/cors/models.py
+++ b/cors/models.py
@@ -4,6 +4,8 @@ from pik.core.models import BasePHistorical
 
 
 class Cors(BasePHistorical):
+    permitted_fields = {'{app_label}.change_{model_name}': ['cors']}
+
     cors = models.CharField(max_length=255, unique=True, help_text=_(
         "Название домена допущенного делать междоменные запросы, например: "
         "staff-front.pik-software.ru или localhost:3000"))

--- a/lib/oidc_relied/tests/test_relied_logout.py
+++ b/lib/oidc_relied/tests/test_relied_logout.py
@@ -1,34 +1,21 @@
 from unittest.mock import patch, Mock
 from urllib.parse import urlencode
 
-import pytest
 
 import django.test
 from django.urls import reverse
 
-from pik.core.tests import create_user
 from rest_framework import status
-
-
-@pytest.fixture
-def user():
-    return create_user(email="oidcclient@email.com", password="oidcpassword")
-
-
-@pytest.fixture
-def logged_user_client(client: django.test.Client, user):
-    client.force_login(user)
-    return client
 
 
 @django.test.override_settings(OIDC_PIK_CLIENT_ID="TEST_CLIENT_ID")
 @patch("social_core.backends.open_id_connect.OpenIdConnectAuth.oidc_config",
        Mock(return_value={
            'end_session_endpoint': 'http://op/openid/end-session/'}))
-def test_logout(logged_user_client):
-    logged_user_client.session['id_token'] = '{testidtoken}'
-    resp = logged_user_client.get(reverse('admin:logout'))
+def test_logout(api_client):
+    api_client.session['id_token'] = '{testidtoken}'
+    resp = api_client.get(reverse('admin:logout'))
     assert resp.status_code == status.HTTP_302_FOUND
     assert resp['Location'] == 'http://op/openid/end-session/?{}'.format(
         urlencode({'post_logout_redirect_uri': 'http://testserver/logout/'}))
-    assert logged_user_client.session.get('id_token') is None
+    assert api_client.session.get('id_token') is None


### PR DESCRIPTION
This PR provides ability to handle per field permissions for your Models, ModelAdmins and Serializers.

This PR includes following changes:

- permitted_fields Model, ModelAdmin and Serializer property handling
- api CRUD permissions handling
- test helpers:
 - fixtures:
   - anon_api_client
   - api_client
   - api_user
 - add_permissions
- contacts example is updated to show permitted_fields functionality
- upd pytest ci command