### PR TITLE
Add -p option to mkdir command

### DIFF
--- a/.circleci/init-dokku-back.sh
+++ b/.circleci/init-dokku-back.sh
@@ -21,7 +21,7 @@ if ssh dokku@${SSH_HOST} -C apps:list | grep -qFx ${SERVICE_NAME}; then
     exit 2
 fi
 
-ssh ${SSH_HOST} -C sudo mkdir "${MEDIA_ROOT}"
+ssh ${SSH_HOST} -C sudo mkdir -p "${MEDIA_ROOT}"
 ssh ${SSH_HOST} -C dokku events:on
 ssh ${SSH_HOST} -C dokku apps:create ${SERVICE_NAME}
 ssh dokku@${SSH_HOST} -C storage:mount ${SERVICE_NAME} "${MEDIA_ROOT}:${MEDIA_ROOT}"


### PR DESCRIPTION
Add -p option to mkdir command to avoid build fail if directory already exists