### PR TITLE
Create media root if not exists

### DIFF
--- a/.circleci/init-dokku-back.sh
+++ b/.circleci/init-dokku-back.sh
@@ -21,7 +21,10 @@ if ssh dokku@${SSH_HOST} -C apps:list | grep -qFx ${SERVICE_NAME}; then
     exit 2
 fi
 
-ssh ${SSH_HOST} -C sudo mkdir "${MEDIA_ROOT}" -p
+if ssh ${SSH_HOST} -C "[ ! -d ${MEDIA_ROOT} ]"; then
+    ssh ${SSH_HOST} -C sudo mkdir "${MEDIA_ROOT}" -p
+fi
+
 ssh ${SSH_HOST} -C dokku events:on
 ssh ${SSH_HOST} -C dokku apps:create ${SERVICE_NAME}
 ssh dokku@${SSH_HOST} -C storage:mount ${SERVICE_NAME} "${MEDIA_ROOT}:${MEDIA_ROOT}"


### PR DESCRIPTION
Добавил проверку на наличие директории `MEDIA_ROOT` при инициализации сервиса.